### PR TITLE
make instance condition simple

### DIFF
--- a/src/Eq.ts
+++ b/src/Eq.ts
@@ -1,24 +1,17 @@
-import {
-  Apply,
-  Kind,
-  TypeConstructor,
-  TypeLambda,
-  Unconstrained,
-} from './TypeLambda'
+import { TypeConstructor } from './TypeLambda'
 
 export const Equals = Symbol()
 export type Equals = typeof Equals
 
-export interface Eq<A, Constraints extends TypeLambda = Unconstrained> {
-  [Equals]: (a: Apply<Constraints, A>) => (b: Apply<Constraints, A>) => boolean
+export interface Eq<A> {
+  [Equals]: (a: A) => (b: A) => boolean
 }
 
 export const equals = <A extends Eq<A>>(a: A) => a[Equals](a)
 
-export const eq =
-  <F extends TypeConstructor>(f: F) =>
-  <Constraints extends TypeLambda = Unconstrained>(
-    def: Eq<InstanceType<F>, Constraints>,
-  ) => {
-    f.prototype[Equals] = def[Equals]
-  }
+export const eq = <F extends TypeConstructor>(
+  f: F,
+  equal: (a: InstanceType<F>) => (b: InstanceType<F>) => boolean,
+) => {
+  f.prototype[Equals] = equal
+}

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -48,19 +48,14 @@ functor(Option, {
 
 // #region Eq instance
 
-interface A_Has_Eq extends TypeLambda {
-  readonly result: this['params'] extends Option<infer A>
-    ? Option<Eq<A>>
-    : never
-}
+export interface Option<A> extends Eq<Option<Eq<A>>> {}
 
-export interface Option<A> extends Eq<Option<A>, A_Has_Eq> {}
-
-eq(Option)<A_Has_Eq>({
-  [Equals]: (a) => (b) =>
+eq(
+  Option<Eq<unknown>>,
+  (a) => (b) =>
     a.value._type === 'some'
       ? b.value._type === 'some' && equals(a.value.value)(b.value.value)
       : b.value._type === 'none',
-})
+)
 
 // #endregion


### PR DESCRIPTION
I think `A_Has_Eq` make the solution more complex, we can simply use the subtyping when defining the interface and for implementation, we really don't need to know anything about the type parameter only that it should have Eq interface.

```typescript
export interface Option<A> extends Eq<Option<Eq<A>>> {}

eq(
  Option<Eq<unknown>>,
  (a) => (b) =>
    a.value._type === 'some'
      ? b.value._type === 'some' && equals(a.value.value)(b.value.value)
      : b.value._type === 'none',
)
```